### PR TITLE
Add BuscaPaginasBlancas to Phone numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -2048,6 +2048,7 @@ DeHashed API tool allows to automate this process and search large lists of inpu
 | [FireFly](https://github.com/Lexxrt/FireFly) | Get information about phone number using Numverify API |
 | [PhoneNumber OSINT](https://github.com/spider863644/PhoneNumber-OSINT) | Simple tool for gathering basic information about phone numbers (country code, timezone, provider) |
 | [Phunter](https://github.com/N0rz3/Phunter) | Phone number #osint command line #python tool. Gather different info: operator, possible(s) location(s), line type, reputation, various scraped information, spammer or not, connect to amazon or not |
+| [BuscaPaginasBlancas](https://github.com/GeiserX/BuscaPaginasBlancas) | #python tool for automated lookups on Spanish white pages (PaginasBlancas.es) to find people's phone numbers and addresses |
 
 [](#universal-contact-search-and-leaks-search)Universal Contact Search and Leaks Search
 =======================================================================================


### PR DESCRIPTION
## Summary
- Adds [BuscaPaginasBlancas](https://github.com/GeiserX/BuscaPaginasBlancas) to the Phone numbers section
- Python tool for automated lookups on Spanish white pages (PaginasBlancas.es) to find people's phone numbers and addresses
- MIT licensed, open source