### PR TITLE
Add Wayback-Archive to web archives tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1871,6 +1871,7 @@ Don't forget that OSINT's main strength is in automation. Read the [Netlas Cookb
 | [Web Archive Google Chrome Extension](https://github.com/husseinphp/web-archive) | Simple Chrome Extensions for getting information about current URL using http://archive.org CDX API |
 | [WAYBACK GOOGLE ANALYTICS](https://github.com/bellingcat/wayback-google-analytics) | A tool that finds all Google Analytics ID in URL (including old ones from Web Archive). |
 | [GAU](https://github.com/lc/gau) | Simple #golang tool to fetch all known website URLs from: WayBackMachine, AlienVault's Open Threat Exchange, Common Crawl, URLScan |
+| [Wayback-Archive](https://github.com/GeiserX/Wayback-Archive) | Download complete websites from the Wayback Machine with full asset preservation for offline viewing. #python GPL-3.0 |
 
 ### [](#warc)Tools for working with WARC (WebARChive) files
 

--- a/README.md
+++ b/README.md
@@ -1871,7 +1871,7 @@ Don't forget that OSINT's main strength is in automation. Read the [Netlas Cookb
 | [Web Archive Google Chrome Extension](https://github.com/husseinphp/web-archive) | Simple Chrome Extensions for getting information about current URL using http://archive.org CDX API |
 | [WAYBACK GOOGLE ANALYTICS](https://github.com/bellingcat/wayback-google-analytics) | A tool that finds all Google Analytics ID in URL (including old ones from Web Archive). |
 | [GAU](https://github.com/lc/gau) | Simple #golang tool to fetch all known website URLs from: WayBackMachine, AlienVault's Open Threat Exchange, Common Crawl, URLScan |
-| [Wayback-Archive](https://github.com/GeiserX/Wayback-Archive) | Download complete websites from the Wayback Machine with full asset preservation for offline viewing. #python GPL-3.0 |
+| [Wayback-Archive](https://github.com/GeiserX/Wayback-Archive) | Download complete websites from the Wayback Machine with full asset preservation for offline viewing. #python |
 
 ### [](#warc)Tools for working with WARC (WebARChive) files
 


### PR DESCRIPTION
## Summary

- Adds [Wayback-Archive](https://github.com/GeiserX/Wayback-Archive) to the "Tools for working with web archives" section.
- Wayback-Archive is a Python (GPL-3.0) tool that downloads complete websites from the Wayback Machine with full asset preservation (HTML, CSS, JS, images) for offline viewing.

## Details

The entry has been added to the existing table in the "Tools for working with web archives" section, following the established format.