### PR TITLE
Add Phantom Tide to Maritime section

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,7 @@ Don't forget that OSINT's main strength is in automation. Read the [Netlas Cookb
 | [Submarine Vessels Tracking Map](https://www.marinevesseltraffic.com/submarine-vessels-tracking-map) |     |
 | [Ports.com](https://ports.com/sea-route/) | online calculation of travel time between two ports (with optimal path). It's possible to select the speed from 5 to 40 knots. Shows a list of the seas through which it passes. |
 | [Live Cruise Ship Tracker](https://www.livecruiseshiptracker.com/) | Large catalogue of cruise ship research materials: - map with trackers; - timetables; - webcams on decks and in ports; - elaborate thematic news aggregator |
+| [Phantom Tide](https://github.com/tg12/phantomtide) | Cross-domain OSINT dashboard that correlates vessel tracking, airspace activity, official notices, environmental context, and satellite detections for maritime and airspace analysis. |
 
 ### [](#railway)Railway
 


### PR DESCRIPTION
This adds Phantom Tide to the Maritime section.

Disclosure: I maintain Phantom Tide and am submitting it for inclusion.

Repository: https://github.com/tg12/phantomtide
Why it fits: Phantom Tide gives analysts one view across vessel traffic, airspace activity, official notices, environmental conditions, and satellite detections.