### PR TITLE
Add Metadata Remover to EXIF tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1580,6 +1580,7 @@ Don't forget that OSINT's main strength is in automation. Read the [Netlas Cookb
 | [EXIF-PY](https://github.com/ianare/exif-py) | get exif data of photos thrue command line |
 | [Exif.app](http://exif.app) | Press "Diff check button", upload two graphical images and get a comparison table of their metadata. The differences are highlighted in yellow |
 | [Image Analyzer Addon](https://chrome.google.com/webstore/detail/image-analyzer/bgadhpbbppdihhbfcjbbihfcckbblcek) | View all images on a page and expose image properties, EXIF data, and one-click download |
+| [Metadata Remover](https://metadataremover.ai/metadata-viewer) | Browser-local viewer for EXIF, GPS, XMP, IPTC, and supported AI metadata in JPG, PNG, and WebP files; no uploads or account. |
 | [Online metadata viewer and editor](https://products.groupdocs.app/metadata/) | High-quality and well-made. Support docx, xlsx, msg, pptx, jpeg, vsd, mpp. |
 | [Scan QR Code](https://4qrcode.com/scan-qr-code.php) | While determining the location of the photo, sometimes the research of QR codes on the road poles, showcases and billboards helps a lot. This service will help to recognize a QR-code by a picture |
 | [Identify plans](https://identify.plantnet.org/) |     |


### PR DESCRIPTION
Disclosure: I maintain [Metadata Remover](https://metadataremover.ai/metadata-viewer).

This adds one browser-local image metadata viewer to the existing Exif Analyze and editing section. It reads EXIF, GPS, XMP, IPTC, and supported AI metadata from JPG, PNG, and WebP files without uploads or an account. The PR contains one factual table row.